### PR TITLE
If init_matrix fails, it will crash

### DIFF
--- a/spmat/spmat_utils.upc
+++ b/spmat/spmat_utils.upc
@@ -113,6 +113,8 @@ sparsemat_t * transpose_matrix(sparsemat_t *omat) {
   //A = transpose_matrix_exstack2(omat, 1024);
   //A = transpose_matrix_conveyor(omat);
 
+  if(!A) 
+     exit(1);
   sort_nonzeros(A);
   return(A);
 }


### PR DESCRIPTION
When init_matrix fails, sort_nonzeros, does not check if matrix A is NULL

ERROR: transpose_matrix: init_matrix failed!
ERROR: transpose_matrix: init_matrix failed!
MPT ERROR: Rank 67(g:67) received signal SIGSEGV(11).
        Process ID: 15343, Host: mdc-sgi-02-t01-ch1, Program: /home/rajakr/bale/build_x86_64/bin/topo
        MPT Version: HPE MPT 2.18  05/12/18 04:23:42

MPT: --------stack traceback-------
MPT: Attaching to program: /proc/15343/exe, process 15343
MPT: done.
MPT: done.
MPT: [Thread debugging using libthread_db enabled]
MPT: Using host libthread_db library "/lib64/libthread_db.so.1".
MPT: (no debugging symbols found)...done.
MPT: (no debugging symbols found)...done.
MPT: done.
MPT: done.
MPT: done.
MPT: done.
MPT: done.
MPT: (no debugging symbols found)...done.
MPT: 0x00007ffff78cc12c in __libc_waitpid (pid=pid@entry=15932,
MPT:     stat_loc=stat_loc@entry=0x7fffffffce40, options=options@entry=0)
MPT:     at ../sysdeps/unix/sysv/linux/waitpid.c:31
MPT: 31       return INLINE_SYSCALL (wait4, 4, pid, stat_loc, options, NULL);
MPT: Missing separate debuginfos, use: debuginfo-install libbitmask-2.0-sgi718r38.rhel74.x86_64 libcpuset-1.0-sgi718r71.rhel74.x86_64 xpmem-1.6-sgi718r76.rhel74.x86_64
MPT: (gdb) #0  0x00007ffff78cc12c in __libc_waitpid (pid=pid@entry=15932,
MPT:     stat_loc=stat_loc@entry=0x7fffffffce40, options=options@entry=0)
MPT:     at ../sysdeps/unix/sysv/linux/waitpid.c:31
MPT: #1  0x00007ffff6f83bc6 in mpi_sgi_system (
MPT: #2  MPI_SGI_stacktraceback (
MPT:     header=header@entry=0x7fffffffd600 "MPT ERROR: Rank 67(g:67) received signal SIGSEGV(11).\n\tProcess ID: 15343, Host: mdc-sgi-02-t01-ch1, Program: /home/rajakr/bale/build_x86_64/bin/topo\n\tMPT Version: HPE MPT 2.18  05/12/18 04:23:42\n") at sig.c:340
MPT: #3  0x00007ffff6f83dc2 in first_arriver_handler (signo=signo@entry=11,
MPT:     stack_trace_sem=stack_trace_sem@entry=0x7ffbf6360080) at sig.c:489
MPT: #4  0x00007ffff6f8415b in slave_sig_handler (signo=11,
MPT:     siginfo=<optimized out>, extra=<optimized out>) at sig.c:564
MPT: #5  <signal handler called>
MPT: #6  sort_nonzeros (mat=mat@entry=0x0) at spmat_utils__c.c:1055
MPT: #7  0x00000000004059c6 in transpose_matrix (omat=omat@entry=0x639e700)
MPT:     at spmat_utils__c.c:116
MPT: #8  0x0000000000401fdf in main (argc=<optimized out>, argv=0x7fffffffe1f8)
MPT:     at topo_src/toposort__c.c:280
MPT: (gdb) A debugging session is active.
MPT:
MPT:    Inferior 1 [process 15343] will be detached.
MPT:
MPT: Quit anyway? (y or n) [answered Y; input not from terminal]
MPT: Detaching from program: /proc/15343/exe, process 15343

